### PR TITLE
refactor(settings): Normalize setttings to match pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,29 +70,6 @@
     types-requests = "^2.32.0.20240622"
 twine = "^5.1.1"
 
-[tool.black]
-    target-version = ["py310"]
-    line-length = 120
-    include = '\.pyi?$'
-    exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-  | foo.py           # also separately exclude a file named foo.py in
-                     # the root of the project
-)
-'''
-
 [tool.pytest.ini_options]
     addopts = ["--import-mode=importlib"]
     log_cli = true

--- a/src/orthw/__init__.py
+++ b/src/orthw/__init__.py
@@ -16,8 +16,8 @@
 # License-Filename: LICENSE
 from __future__ import annotations
 
-from orthw.utils.config import Config
+from orthw.utils.settings import Settings
 
 """Make config object global
 """
-config: Config = Config()
+settings: Settings = Settings()

--- a/src/orthw/commands/analyze.py
+++ b/src/orthw/commands/analyze.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 from docker.models.containers import Container
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
@@ -56,9 +56,9 @@ def analyze(
     ]
 
     if not docker:
-        if config.ort_config_package_curations_dir.exists():
+        if settings.ort_config_package_curations_dir.exists():
             args.append("--package-curations-dir")
-            args.append(config.ort_config_package_curations_dir.as_posix())
+            args.append(settings.ort_config_package_curations_dir.as_posix())
         else:
             logging.warning("No curations folder available. Running without curations.")
 

--- a/src/orthw/commands/clean.py
+++ b/src/orthw/commands/clean.py
@@ -16,25 +16,25 @@
 # License-Filename: LICENSE
 from __future__ import annotations
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.cmdgroups import command_group
 
 
 def clean() -> None:
     try:
-        dot_dir = config.configdir
+        dot_dir = settings.configdir
         if dot_dir and dot_dir.is_dir():
             logging.info(f"Removed directory {dot_dir}")
     except OSError:
         logging.error(f"Removing directory {dot_dir}")
     try:
-        config_file = config.repository_configuration_file
+        config_file = settings.repository_configuration_file
         if config_file and config_file.is_file():
             config_file.unlink(missing_ok=True)
             logging.info(f"Removed file {config_file}")
     except OSError:
-        logging.error(f"Error removing directory {config.repository_configuration_file}")
+        logging.error(f"Error removing directory {settings.repository_configuration_file}")
 
 
 @command_group.command(

--- a/src/orthw/commands/copyrights.py
+++ b/src/orthw/commands/copyrights.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
@@ -36,9 +36,9 @@ def copyrights(package_id: str = "") -> None:
 
     require_initialized()
 
-    ort_config_copyright_garbage_file: Path = config.ort_config_copyright_garbage_file
-    ort_config_package_configuration_dir: Path = config.ort_config_package_configuration_dir
-    scan_result_file: Path = config.scan_result_file
+    ort_config_copyright_garbage_file: Path = settings.ort_config_copyright_garbage_file
+    ort_config_package_configuration_dir: Path = settings.ort_config_package_configuration_dir
+    scan_result_file: Path = settings.scan_result_file
 
     if not scan_result_file or not ort_config_package_configuration_dir or not ort_config_copyright_garbage_file:
         logging.error("Invalid configuration.")
@@ -57,10 +57,10 @@ def copyrights(package_id: str = "") -> None:
             ort_config_package_configuration_dir.as_posix(),
         ]
 
-        run(args=args, output_file=config.copyrights_file)
+        run(args=args, output_file=settings.copyrights_file)
 
         args += ["--show-raw-statements"]
-        run(args=args, output_file=config.copyrights_debug_file)
+        run(args=args, output_file=settings.copyrights_debug_file)
 
 
 @command_group.command(

--- a/src/orthw/commands/evaluate.py
+++ b/src/orthw/commands/evaluate.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 from docker.models.containers import Container
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
@@ -48,21 +48,21 @@ def evaluate(
         "ort",
         "evaluate",
         "--copyright-garbage-file",
-        config.ort_config_copyright_garbage_file.as_posix(),
+        settings.ort_config_copyright_garbage_file.as_posix(),
         "--package-curations-dir",
-        config.ort_config_package_curations_dir.as_posix(),
+        settings.ort_config_package_curations_dir.as_posix(),
         "--output-formats",
         format_,
         "--ort-file",
         ort_file.name,
         "--repository-configuration-file",
-        config.repository_configuration_file.as_posix(),
+        settings.repository_configuration_file.as_posix(),
         "--rules-file",
-        config.ort_config_rules_file.as_posix(),
+        settings.ort_config_rules_file.as_posix(),
         "--license-classifications-file",
-        config.ort_config_license_classifications_file.as_posix(),
+        settings.ort_config_license_classifications_file.as_posix(),
         "--package-configuration-dir",
-        config.ort_config_package_configuration_dir.as_posix(),
+        settings.ort_config_package_configuration_dir.as_posix(),
     ]
 
     # Execute external run

--- a/src/orthw/commands/export_copyright_garbage.py
+++ b/src/orthw/commands/export_copyright_garbage.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from rich.pretty import pprint
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
@@ -32,9 +32,9 @@ def export_copyright_garbage() -> None:
     """Command export-copyright-garbage"""
     require_initialized()
 
-    copyrights_file: Path = config.copyrights_file
-    ort_config_copyright_garbage_file: Path = config.ort_config_copyright_garbage_file
-    scan_result_file: Path = config.scan_result_file
+    copyrights_file: Path = settings.copyrights_file
+    ort_config_copyright_garbage_file: Path = settings.ort_config_copyright_garbage_file
+    scan_result_file: Path = settings.scan_result_file
     if (
         copyrights_file.is_file() is None
         or not ort_config_copyright_garbage_file.is_file()
@@ -71,7 +71,7 @@ def export_copyright_garbage() -> None:
         "--input-copyright-garbage-file",
         mapped_copyrights_file.as_posix(),
         "--output-copyright-garbage-file",
-        config.ort_config_copyright_garbage_file.as_posix(),
+        settings.ort_config_copyright_garbage_file.as_posix(),
     ]
     run(args=args)
 

--- a/src/orthw/commands/find_license_url.py
+++ b/src/orthw/commands/find_license_url.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 import git
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import command_group
 
 
@@ -30,9 +30,9 @@ def find_license_url(license_id: str) -> str:
         key = license_id.strip("LicenseRef-scancode-")
         license_file_path = f"src/licensedcode/data/licenses/{key}.LICENSE"
 
-        license_file: Path = config.scancode_home / license_file_path
+        license_file: Path = settings.scancode_home / license_file_path
         if license_file.exists():
-            git_repo = git.repo.Repo(config.scancode_home.as_posix())
+            git_repo = git.repo.Repo(settings.scancode_home.as_posix())
             revision = git_repo.git.rev_parse("HEAD")
             return f"https://github.com/nexB/scancode-toolkit/blob/{revision}/{license_file_path}"
 

--- a/src/orthw/commands/handled_licenses.py
+++ b/src/orthw/commands/handled_licenses.py
@@ -16,7 +16,7 @@
 # License-Filename: LICENSE
 from __future__ import annotations
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
 
@@ -28,7 +28,7 @@ def handled_licenses() -> None:
         "orth",
         "list-license-categories",
         "--license-classifications-file",
-        config.ort_config_license_classifications_file.as_posix(),
+        settings.ort_config_license_classifications_file.as_posix(),
     ]
 
     run(args)

--- a/src/orthw/commands/handled_licenses_by_category.py
+++ b/src/orthw/commands/handled_licenses_by_category.py
@@ -16,7 +16,7 @@
 # License-Filename: LICENSE
 from __future__ import annotations
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
 
@@ -28,7 +28,7 @@ def handled_licenses_by_category() -> None:
         "orth",
         "list-license-categories",
         "--license-classifications-file",
-        config.ort_config_license_classifications_file.as_posix(),
+        settings.ort_config_license_classifications_file.as_posix(),
         "--group-by-category",
     ]
 

--- a/src/orthw/commands/init.py
+++ b/src/orthw/commands/init.py
@@ -27,7 +27,7 @@ import requests
 import yaml
 from docker.models.containers import Container
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
@@ -41,7 +41,7 @@ def init(target_url: str) -> int | Container:
     logging.debug(f"filename: {filename}")
     logging.debug(f"extension: {extension}")
 
-    evaluation_md5_sum_file: Path = config.evaluation_md5_sum_file
+    evaluation_md5_sum_file: Path = settings.evaluation_md5_sum_file
     if evaluation_md5_sum_file.exists():
         evaluation_md5_sum_file.unlink()
 
@@ -82,7 +82,7 @@ def init(target_url: str) -> int | Container:
             "orth",
             "extract-repository-configuration",
             "--repository-configuration-file",
-            config.repository_configuration_file.as_posix(),
+            settings.repository_configuration_file.as_posix(),
             "--ort-file",
             scan_result_file.as_posix(),
         ]
@@ -97,7 +97,7 @@ def init(target_url: str) -> int | Container:
             "--ort-file",
             scan_result_file.as_posix(),
             "--scan-results-storage-dir",
-            config.scan_results_storage_dir.as_posix(),
+            settings.scan_results_storage_dir.as_posix(),
         ]
 
         return run(args)

--- a/src/orthw/commands/licenses.py
+++ b/src/orthw/commands/licenses.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -42,9 +42,9 @@ def licenses(package_id: str, source_code_dir: str | None = None) -> None:
         "--omit-excluded",
     ]
 
-    args += ["--ort-file", config.evaluation_result_file.as_posix()]
-    args += ["--repository-configuration-file", config.repository_configuration_file.as_posix()]
-    args += ["--package-configuration-dir", config.ort_config_package_configuration_dir.as_posix()]
+    args += ["--ort-file", settings.evaluation_result_file.as_posix()]
+    args += ["--repository-configuration-file", settings.repository_configuration_file.as_posix()]
+    args += ["--package-configuration-dir", settings.ort_config_package_configuration_dir.as_posix()]
 
     if source_code_dir:
         args += ["--source-code-dir", source_code_dir]

--- a/src/orthw/commands/offending_packages.py
+++ b/src/orthw/commands/offending_packages.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,7 +27,7 @@ from orthw.utils.required import require_initialized
 def offending_packages() -> None:
     require_initialized()
 
-    scan_result_file: Path = config.scan_result_file
+    scan_result_file: Path = settings.scan_result_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/package_config/clean.py
+++ b/src/orthw/commands/package_config/clean.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import package_config_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -30,7 +30,7 @@ def clean(package_id: str) -> None:
     require_initialized()
 
     package_configuration_file = "FIXME find_package(package_id)"
-    scan_result_file: Path = config.scan_result_file
+    scan_result_file: Path = settings.scan_result_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/package_config/create.py
+++ b/src/orthw/commands/package_config/create.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import package_config_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -29,11 +29,11 @@ from orthw.utils.required import require_initialized
 def create(package_id: str) -> None:
     require_initialized()
 
-    scan_results_storage_dir: Path = config.scan_results_storage_dir
-    ort_config_license_classifications_file: Path = config.ort_config_license_classifications_file
-    non_offending_license_categories = config.non_offending_license_categories
-    non_offending_license_ids = config.non_offending_license_ids
-    ort_config_package_configurations_dir: Path = config.ort_config_package_configurations_dir
+    scan_results_storage_dir: Path = settings.scan_results_storage_dir
+    ort_config_license_classifications_file: Path = settings.ort_config_license_classifications_file
+    non_offending_license_categories = settings.non_offending_license_categories
+    non_offending_license_ids = settings.non_offending_license_ids
+    ort_config_package_configurations_dir: Path = settings.ort_config_package_configurations_dir
 
     args: list[str] = [
         "orth",
@@ -70,10 +70,10 @@ def create(package_id: str) -> None:
 
         orthw package-config create Maven:org.apache.curator:curator-framework:2.13.0
     """.format(
-        dir=config.ort_config_package_configurations_dir,
+        dir=settings.ort_config_package_configurations_dir,
     ),
     short_help=f"Creates one package configuration in '{dir}' for given package id.".format(
-        dir=config.ort_config_package_configurations_dir,
+        dir=settings.ort_config_package_configurations_dir,
     ),
 )
 @click.argument("package_id")

--- a/src/orthw/commands/package_config/export_curations.py
+++ b/src/orthw/commands/package_config/export_curations.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import package_config_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -30,8 +30,8 @@ def export_curations(package_id: str, source_code_dir: str) -> None:
     require_initialized()
 
     package_configuration_file = "FIXME find_package(package_id)"
-    exports_license_finding_curations_file: Path = config.exports_license_finding_curations_file
-    exports_vcs_url_mapping_file: Path = config.exports_vcs_url_mapping_file
+    exports_license_finding_curations_file: Path = settings.exports_license_finding_curations_file
+    exports_vcs_url_mapping_file: Path = settings.exports_vcs_url_mapping_file
 
     args: list[str] = [
         "orth",
@@ -61,10 +61,10 @@ def export_curations(package_id: str, source_code_dir: str) -> None:
 
         orthw package-config export-curations {package_id} /home/ort-user/code-repo/
     """.format(
-        file=config.exports_license_finding_curations_file,
+        file=settings.exports_license_finding_curations_file,
         package_id="Maven:org.apache.curator:curator-framework:2.13.0",
     ),
-    short_help=f"Exports the license finding curations to '{config.exports_license_finding_curations_file}'.",
+    short_help=f"Exports the license finding curations to '{settings.exports_license_finding_curations_file}'.",
 )
 @click.argument("package_id")
 @click.argument("source_code_dir")

--- a/src/orthw/commands/package_config/export_path_excludes.py
+++ b/src/orthw/commands/package_config/export_path_excludes.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import package_config_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -30,8 +30,8 @@ def export_path_excludes(package_id: str, source_code_dir: str) -> None:
     require_initialized()
 
     package_configuration_file = "FIXME find_package(package_id)"
-    exports_path_excludes_file: Path = config.exports_path_excludes_file
-    exports_vcs_url_mapping_file: Path = config.exports_vcs_url_mapping_file
+    exports_path_excludes_file: Path = settings.exports_path_excludes_file
+    exports_vcs_url_mapping_file: Path = settings.exports_vcs_url_mapping_file
 
     args: list[str] = [
         "orth",
@@ -61,10 +61,10 @@ def export_path_excludes(package_id: str, source_code_dir: str) -> None:
 
         orthw package-config export-path-excludes {package_id} /home/ort-user/code-repo/
     """.format(
-        file=config.exports_path_excludes_file,
+        file=settings.exports_path_excludes_file,
         package_id="Maven:org.apache.curator:curator-framework:2.13.0",
     ),
-    short_help=f"Exports path excludes for given package id to '{config.exports_path_excludes_file}'.",
+    short_help=f"Exports path excludes for given package id to '{settings.exports_path_excludes_file}'.",
 )
 @click.argument("package_id")
 @click.argument("source_code_dir")

--- a/src/orthw/commands/package_config/find.py
+++ b/src/orthw/commands/package_config/find.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import package_config_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -29,7 +29,7 @@ from orthw.utils.required import require_initialized
 def find(package_id: str) -> None:
     require_initialized()
 
-    ort_config_package_configurations_dir: Path = config.ort_config_package_configurations_dir
+    ort_config_package_configurations_dir: Path = settings.ort_config_package_configurations_dir
 
     args: list[str] = [
         "orth",
@@ -48,14 +48,14 @@ def find(package_id: str) -> None:
     context="PACKAGE_CONFIG",
     name="find",
     help=f"""
-        Searches '{config.ort_config_package_configurations_dir}' for a package configurations with given package id.
+        Searches '{settings.ort_config_package_configurations_dir}' for a package configurations with given package id.
 
         Examples:
 
         orthw package-config find Maven:org.apache.curator:curator-framework:2.13.0
     """,
     short_help=(
-        f"Searches '{config.ort_config_package_configurations_dir}' "
+        f"Searches '{settings.ort_config_package_configurations_dir}' "
         "for a package configuration with given package id."
     ),
 )

--- a/src/orthw/commands/package_config/import_curations.py
+++ b/src/orthw/commands/package_config/import_curations.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import package_config_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -30,8 +30,8 @@ def import_curations(package_id: str, source_code_dir: str) -> None:
     require_initialized()
 
     package_configuration_file = "FIXME find_package(package_id)"
-    exports_license_finding_curations_file: Path = config.exports_license_finding_curations_file
-    scan_result_file: Path = config.scan_result_file
+    exports_license_finding_curations_file: Path = settings.exports_license_finding_curations_file
+    scan_result_file: Path = settings.scan_result_file
 
     args: list[str] = [
         "orth",
@@ -60,11 +60,11 @@ def import_curations(package_id: str, source_code_dir: str) -> None:
 
         orthw package-config import-curations {package_id} /home/ort-user/code-repo/
     """.format(
-        file=config.exports_license_finding_curations_file,
+        file=settings.exports_license_finding_curations_file,
         package_id="Maven:org.apache.curator:curator-framework:2.13.0",
     ),
     short_help=(
-        f"Imports license finding curations from '{config.exports_license_finding_curations_file}' "
+        f"Imports license finding curations from '{settings.exports_license_finding_curations_file}' "
         "into package configuration file for given package id."
     ),
 )

--- a/src/orthw/commands/package_config/import_path_excludes.py
+++ b/src/orthw/commands/package_config/import_path_excludes.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import package_config_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -30,7 +30,7 @@ def import_path_excludes(package_id: str, source_code_dir: str) -> None:
     require_initialized()
 
     package_configuration_file = "FIXME find_package(package_id)"
-    exports_path_excludes_file: Path = config.exports_path_excludes_file
+    exports_path_excludes_file: Path = settings.exports_path_excludes_file
 
     args: list[str] = [
         "orth",
@@ -57,11 +57,11 @@ def import_path_excludes(package_id: str, source_code_dir: str) -> None:
 
         orthw package-config import-path-excludes {package_id} /home/ort-user/code-repo/
     """.format(
-        file=config.exports_path_excludes_file,
+        file=settings.exports_path_excludes_file,
         package_id="Maven:org.apache.curator:curator-framework:2.13.0",
     ),
     short_help=(
-        f"Imports path excludes from '{config.exports_path_excludes_file}' "
+        f"Imports path excludes from '{settings.exports_path_excludes_file}' "
         "into package configuration file for given package id."
     ),
 )

--- a/src/orthw/commands/packages.py
+++ b/src/orthw/commands/packages.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import command_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,7 +27,7 @@ from orthw.utils.required import require_initialized
 def packages() -> None:
     require_initialized()
 
-    scan_result_file: Path = config.scan_result_file
+    scan_result_file: Path = settings.scan_result_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/clean.py
+++ b/src/orthw/commands/repository_config/clean.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
@@ -33,9 +33,9 @@ def clean(source_code_dir: str) -> None:
     # FIXME implement args to call evaluate
     # evaluate()
 
-    evaluation_result_file: Path = config.evaluation_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
-    ort_config_resolutions_file: Path = config.ort_config_resolutions_file
+    evaluation_result_file: Path = settings.evaluation_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
+    ort_config_resolutions_file: Path = settings.ort_config_resolutions_file
 
     logging.debug(f"source_code_dir: {source_code_dir}")
 

--- a/src/orthw/commands/repository_config/export_curations.py
+++ b/src/orthw/commands/repository_config/export_curations.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,10 +27,10 @@ from orthw.utils.required import require_initialized
 def export_curations() -> None:
     require_initialized()
 
-    exports_license_finding_curations_file: Path = config.exports_license_finding_curations_file
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
-    exports_vcs_url_mapping_file: Path = config.exports_vcs_url_mapping_file
+    exports_license_finding_curations_file: Path = settings.exports_license_finding_curations_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
+    exports_vcs_url_mapping_file: Path = settings.exports_vcs_url_mapping_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/export_path_excludes.py
+++ b/src/orthw/commands/repository_config/export_path_excludes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,10 +27,10 @@ from orthw.utils.required import require_initialized
 def export_path_excludes() -> None:
     require_initialized()
 
-    exports_path_excludes_file: Path = config.exports_path_excludes_file
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
-    exports_vcs_url_mapping_file: Path = config.exports_vcs_url_mapping_file
+    exports_path_excludes_file: Path = settings.exports_path_excludes_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
+    exports_vcs_url_mapping_file: Path = settings.exports_vcs_url_mapping_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/format.py
+++ b/src/orthw/commands/repository_config/format.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,7 +27,7 @@ from orthw.utils.required import require_initialized
 def format_() -> None:
     require_initialized()
 
-    repository_configuration_file: Path = config.repository_configuration_file
+    repository_configuration_file: Path = settings.repository_configuration_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/generate_project_excludes.py
+++ b/src/orthw/commands/repository_config/generate_project_excludes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,8 +27,8 @@ from orthw.utils.required import require_initialized
 def generate_project_excludes() -> None:
     require_initialized()
 
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/generate_rule_violation_resolutions.py
+++ b/src/orthw/commands/repository_config/generate_rule_violation_resolutions.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,8 +27,8 @@ from orthw.utils.required import require_initialized
 def generate_rule_violation_resolutions() -> None:
     require_initialized()
 
-    evaluation_result_file: Path = config.evaluation_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
+    evaluation_result_file: Path = settings.evaluation_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/generate_scope_excludes.py
+++ b/src/orthw/commands/repository_config/generate_scope_excludes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,8 +27,8 @@ from orthw.utils.required import require_initialized
 def generate_scope_excludes() -> None:
     require_initialized()
 
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/generate_timeout_error_resolutions.py
+++ b/src/orthw/commands/repository_config/generate_timeout_error_resolutions.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,9 +27,9 @@ from orthw.utils.required import require_initialized
 def generate_timeout_error_resolutions() -> None:
     require_initialized()
 
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
-    ort_config_resolutions_file: Path = config.ort_config_resolutions_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
+    ort_config_resolutions_file: Path = settings.ort_config_resolutions_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/commands/repository_config/import_curations.py
+++ b/src/orthw/commands/repository_config/import_curations.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,9 +27,9 @@ from orthw.utils.required import require_initialized
 def import_curations() -> None:
     require_initialized()
 
-    exports_license_finding_curations_file: Path = config.exports_license_finding_curations_file
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
+    exports_license_finding_curations_file: Path = settings.exports_license_finding_curations_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
 
     args: list[str] = [
         "orth",
@@ -50,11 +50,11 @@ def import_curations() -> None:
     context="REPOSITORY_CONFIG",
     name="import-curations",
     help=(
-        f"Imports license finding curations from '{config.exports_license_finding_curations_file}' "
+        f"Imports license finding curations from '{settings.exports_license_finding_curations_file}' "
         "merges them into the ort.yml file."
     ),
     short_help=(
-        f"Imports license finding curations from '{str(config.exports_license_finding_curations_file)}' "
+        f"Imports license finding curations from '{str(settings.exports_license_finding_curations_file)}' "
         "merges them into the ort.yml file."
     ),
 )

--- a/src/orthw/commands/repository_config/import_curations_update_only.py
+++ b/src/orthw/commands/repository_config/import_curations_update_only.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,9 +27,9 @@ from orthw.utils.required import require_initialized
 def import_curations_update_only() -> None:
     require_initialized()
 
-    exports_license_finding_curations_file: Path = config.exports_license_finding_curations_file
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
+    exports_license_finding_curations_file: Path = settings.exports_license_finding_curations_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
 
     args: list[str] = [
         "orth",
@@ -51,11 +51,11 @@ def import_curations_update_only() -> None:
     context="REPOSITORY_CONFIG",
     name="import-curations-update-only",
     help=(
-        f"Imports license finding curations from {config.exports_license_finding_curations_file} "
+        f"Imports license finding curations from {settings.exports_license_finding_curations_file} "
         "to update existing entries in the ort.yml file."
     ),
     short_help=(
-        f"Imports license finding curations from {config.exports_license_finding_curations_file} "
+        f"Imports license finding curations from {settings.exports_license_finding_curations_file} "
         "to update existing entries in the ort.yml file."
     ),
 )

--- a/src/orthw/commands/repository_config/import_path_excludes.py
+++ b/src/orthw/commands/repository_config/import_path_excludes.py
@@ -18,20 +18,20 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
 
-exports_path_excludes_file: Path = config.exports_path_excludes_file
+exports_path_excludes_file: Path = settings.exports_path_excludes_file
 
 
 def import_path_excludes() -> None:
     require_initialized()
 
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
-    exports_vcs_url_mapping_file: Path = config.exports_vcs_url_mapping_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
+    exports_vcs_url_mapping_file: Path = settings.exports_vcs_url_mapping_file
 
     args: list[str] = [
         "orth",
@@ -54,11 +54,11 @@ def import_path_excludes() -> None:
     context="REPOSITORY_CONFIG",
     name="import-path-excludes",
     help=(
-        f"Imports path excludes by repository from '{config.exports_license_finding_curations_file}' "
+        f"Imports path excludes by repository from '{settings.exports_license_finding_curations_file}' "
         " into the ort.yml file."
     ),
     short_help=(
-        f"Import path excludes by repository from '{config.exports_license_finding_curations_file}' "
+        f"Import path excludes by repository from '{settings.exports_license_finding_curations_file}' "
         "into the ort.yml file."
     ),
 )

--- a/src/orthw/commands/repository_config/import_path_excludes_update_only.py
+++ b/src/orthw/commands/repository_config/import_path_excludes_update_only.py
@@ -18,20 +18,20 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
 
-exports_path_excludes_file: Path = config.exports_path_excludes_file
+exports_path_excludes_file: Path = settings.exports_path_excludes_file
 
 
 def import_path_excludes_update_only() -> None:
     require_initialized()
 
-    scan_result_file: Path = config.scan_result_file
-    repository_configuration_file: Path = config.repository_configuration_file
-    exports_vcs_url_mapping_file: Path = config.exports_vcs_url_mapping_file
+    scan_result_file: Path = settings.scan_result_file
+    repository_configuration_file: Path = settings.repository_configuration_file
+    exports_vcs_url_mapping_file: Path = settings.exports_vcs_url_mapping_file
 
     args: list[str] = [
         "orth",
@@ -55,11 +55,11 @@ def import_path_excludes_update_only() -> None:
     context="REPOSITORY_CONFIG",
     name="import-path-excludes-update-only",
     help=(
-        f"Imports path excludes by repository from '{config.exports_license_finding_curations_file}' "
+        f"Imports path excludes by repository from '{settings.exports_license_finding_curations_file}' "
         "into the ort.yml file."
     ),
     short_help=(
-        f"Imports path excludes by repository from '{config.exports_license_finding_curations_file}' "
+        f"Imports path excludes by repository from '{settings.exports_license_finding_curations_file}' "
         "into the ort.yml file."
     ),
 )

--- a/src/orthw/commands/repository_config/sort.py
+++ b/src/orthw/commands/repository_config/sort.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils.cmdgroups import repository_group
 from orthw.utils.process import run
 from orthw.utils.required import require_initialized
@@ -27,7 +27,7 @@ from orthw.utils.required import require_initialized
 def sort_() -> None:
     require_initialized()
 
-    repository_configuration_file: Path = config.repository_configuration_file
+    repository_configuration_file: Path = settings.repository_configuration_file
 
     args: list[str] = [
         "orth",

--- a/src/orthw/utils/checksum.py
+++ b/src/orthw/utils/checksum.py
@@ -20,7 +20,7 @@ import hashlib
 from enum import Enum
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 
 
@@ -31,9 +31,9 @@ class FolderType(Enum):
 
 def check_evaluation_md5_sum() -> bool:
     """Checks whether the evaluator inputs changed."""
-    evaluation_md5_sum_file: Path = config.evaluation_md5_sum_file
-    package_configuration_md5_sum_file: Path = config.package_configuration_md5_sum_file
-    package_curations_md5_sum_file: Path = config.package_curations_md5_sum_file
+    evaluation_md5_sum_file: Path = settings.evaluation_md5_sum_file
+    package_configuration_md5_sum_file: Path = settings.package_configuration_md5_sum_file
+    package_curations_md5_sum_file: Path = settings.package_curations_md5_sum_file
 
     if evaluation_md5_sum_file.exists():
         md5_res = get_folder_md5(FolderType.CONFIGURATION)
@@ -79,9 +79,9 @@ def get_folder_md5(folder_type: str | FolderType) -> str | None:
 
     if isinstance(folder_type, FolderType):
         if folder_type == FolderType.CONFIGURATION:
-            folder = config.ort_config_package_configurations_dir
+            folder = settings.ort_config_package_configurations_dir
         elif folder_type == FolderType.CURATIONS:
-            folder = config.ort_config_package_curations_dir
+            folder = settings.ort_config_package_curations_dir
     elif isinstance(folder_type, str):
         folder = Path(folder_type)
 

--- a/src/orthw/utils/database.py
+++ b/src/orthw/utils/database.py
@@ -23,17 +23,17 @@ from psycopg2.sql import Literal
 from pydantic import BaseModel
 from rich.pretty import pprint
 
-from orthw import config
+from orthw import settings
 from orthw.utils import admin, logging
 
 
 class PostgresConfig(BaseModel):
-    pg_db: str | None = config.scandb_db
-    pg_host: str | None = config.scandb_host
-    pg_port: str | None = config.scandb_port
-    pg_schema: str | None = config.scandb_schema
-    pg_user: str | None = config.scandb_user
-    pg_password: str | None = config.scandb_password
+    pg_db: str | None = settings.scandb_db
+    pg_host: str | None = settings.scandb_host
+    pg_port: str | None = settings.scandb_port
+    pg_schema: str | None = settings.scandb_schema
+    pg_user: str | None = settings.scandb_user
+    pg_password: str | None = settings.scandb_password
 
     def __init__(self) -> None:
         for key, value in self.__dict__.items():

--- a/src/orthw/utils/docker.py
+++ b/src/orthw/utils/docker.py
@@ -23,7 +23,7 @@ import docker
 from docker.models.containers import Container
 from docker.types import Mount
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 from orthw.utils.required import required_command
 
@@ -49,7 +49,7 @@ def _run_in_docker(
     """
     mounts: list[Mount] = []
     client = docker.from_env()
-    docker_image: str = config.ort_docker_image
+    docker_image: str = settings.ort_docker_image
 
     # Check if docker is available on system
     if not required_command("docker"):

--- a/src/orthw/utils/orthwclickgroup.py
+++ b/src/orthw/utils/orthwclickgroup.py
@@ -27,7 +27,7 @@ from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
 
-from orthw import config
+from orthw import settings
 
 
 class OrtHwClickGroup(click.Group):
@@ -44,11 +44,11 @@ class OrtHwClickGroup(click.Group):
         console.print(
             "\n[bright_white]Usage:\n"
             "\nConfiguration:\n\n"
-            f"[bright_green]ORTHW config:[/bright_green] {config.configfile}\n"
-            f"[bright_green]ORT config home:[/bright_green] {config.configuration_home}\n"
-            f"[bright_green]ORT home:[/bright_green] {config.ort_home}\n"
-            f"[bright_green]Scancode home:[/bright_green] {config.scancode_home}\n"
-            f"[bright_green]Exports home:[/bright_green] {config.exports_home}\n"
+            f"[bright_green]ORTHW config:[/bright_green] {settings.ORTHW_CONFIG_FILE}\n"
+            f"[bright_green]ORT config home:[/bright_green] {settings.configuration_home}\n"
+            f"[bright_green]ORT home:[/bright_green] {settings.ort_home}\n"
+            f"[bright_green]Scancode home:[/bright_green] {settings.scancode_home}\n"
+            f"[bright_green]Exports home:[/bright_green] {settings.exports_home}\n"
             "[/bright_white]",
         )
 

--- a/src/orthw/utils/required.py
+++ b/src/orthw/utils/required.py
@@ -20,7 +20,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from orthw import config
+from orthw import settings
 from orthw.utils import logging
 
 required_commands = ["md5sum"]
@@ -56,7 +56,7 @@ def bootstrap_commands() -> bool:
 
 def require_initialized() -> None:
     """Check the base config directories required for operations"""
-    target_url_file: Path = config.target_url_file
+    target_url_file: Path = settings.target_url_file
 
     if target_url_file is None or not target_url_file.is_file():
         logging.error("The working directory is not initialized. Please run 'orthw init <target-url>' first.")

--- a/src/orthw/utils/settings.py
+++ b/src/orthw/utils/settings.py
@@ -22,17 +22,25 @@ from appdirs import AppDirs
 from yaml_settings_pydantic import BaseYamlSettings, YamlSettingsConfigDict
 
 
-class Config(BaseYamlSettings):
+class Settings(BaseYamlSettings):
     """Base config object. Reads default orthw config file or set default"""
 
-    configdir: Path = Path(AppDirs("orthw").user_config_dir)
-    configfile: Path = Path(AppDirs("orthw").user_config_dir) / "config.yml"
+    ORTHW_CONFIG_DIR: Path = Path(AppDirs("orthw").user_config_dir)
+    ORTHW_CONFIG_FILE: Path = Path(AppDirs("orthw").user_config_dir) / "settings.yml"
 
-    model_config = YamlSettingsConfigDict(yaml_files=configfile.as_posix(), extra="allow")
+    try:
+        model_config = YamlSettingsConfigDict(
+            yaml_files=ORTHW_CONFIG_FILE.as_posix(),
+            case_sensitive=True,
+            env_file=(".env", ".env.prod"),
+            extra="allow",
+        )
+    except ValueError as e:
+        print(e)
 
-    configuration_home: Path = configdir / "ort-config"
+    configuration_home: Path = ORTHW_CONFIG_DIR / "ort-config"
     enabled_advisors: str | None = "osv"
-    exports_home: Path = configdir / "exports"
+    exports_home: Path = ORTHW_CONFIG_DIR / "exports"
     gitlab_host: str | None = "gitlab.example.com"
     gitlab_token: str | None = None
     ignore_excluded_rule_ids: str | None = None
@@ -45,12 +53,12 @@ class Config(BaseYamlSettings):
     ort_docker_registry_password: str | None = None
     ort_docker_registry_server: str | None = None
     ort_docker_registry_username: str | None = None
-    ort_home: Path = configdir / "ort"
+    ort_home: Path = ORTHW_CONFIG_DIR / "ort"
     ort_jvm_options: str | None = "-Xmx16G"
     ort_options: str | None = "--info"
     orth_jvm_options: str | None = "-Xmx16G"
     orth_options: str | None = None
-    scancode_home: Path = configdir / "scancode-toolkit"
+    scancode_home: Path = ORTHW_CONFIG_DIR / "scancode-toolkit"
     scancode_version: str = "32.1.0"
     scandb_db: str | None = None
     scandb_host: str | None = None
@@ -60,14 +68,14 @@ class Config(BaseYamlSettings):
     scandb_user: str | None = None
 
     # Config directory files
-    evaluation_md5_sum_file: Path = configdir / "evaluation-md5sum.txt"
-    evaluation_result_file: Path = configdir / "evaluation-result.json"
-    package_configuration_md5_sum_file: Path = configdir / "package-configuration-md5sum.txt"
-    package_curations_md5_sum_file: Path = configdir / "package-curations-md5sum.txt"
-    scan_result_file: Path = configdir / "scan-result.json"
-    scan_results_storage_dir: Path = configdir / "scan-results"
-    target_url_file: Path = configdir / "target-url.txt"
-    temp_dir: Path = configdir / "tmp"
+    evaluation_md5_sum_file: Path = ORTHW_CONFIG_DIR / "evaluation-md5sum.txt"
+    evaluation_result_file: Path = ORTHW_CONFIG_DIR / "evaluation-result.json"
+    package_configuration_md5_sum_file: Path = ORTHW_CONFIG_DIR / "package-configuration-md5sum.txt"
+    package_curations_md5_sum_file: Path = ORTHW_CONFIG_DIR / "package-curations-md5sum.txt"
+    scan_result_file: Path = ORTHW_CONFIG_DIR / "scan-result.json"
+    scan_results_storage_dir: Path = ORTHW_CONFIG_DIR / "scan-results"
+    target_url_file: Path = ORTHW_CONFIG_DIR / "target-url.txt"
+    temp_dir: Path = ORTHW_CONFIG_DIR / "tmp"
 
     # Configuration (repository) files
     ort_config_copyright_garbage_file: Path = configuration_home / "copyright-garbage.yml"


### PR DESCRIPTION
- Refactored config naming to settings to match pydantic settings naming structure.
- Enabled .env / .env.prod evaluation capability .
- Add ORTHW_CONFIG_DIR and ORTHW_CONFIG_FILE variables that can be evaluated in runtime bypassing as environment file or inside .env. The variables are case sensitive.